### PR TITLE
lxqt-panel/Kbindicator: Fixes a QLabel issue in the config dialog

### DIFF
--- a/themes/ambiance/lxqt-panel.qss
+++ b/themes/ambiance/lxqt-panel.qss
@@ -393,7 +393,7 @@ TrayIcon {
     border: 0px;
 }
 
-#KbIndicator QLabel:enabled {
+#KbIndicator > QLabel:enabled {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #f88657, stop:1 #eb7140);
     color: #f2f1f0;
     border: 1px solid #ca5f34;

--- a/themes/dark/lxqt-panel.qss
+++ b/themes/dark/lxqt-panel.qss
@@ -448,17 +448,17 @@ QMenu::indicator:non-exclusive:checked {
 /*
  * KbIndicator
  */
-#KbIndicator QLabel {
+#KbIndicator > QLabel {
     padding: 3px;
     border: 0px;
     font: bold;
 }
 
-#KbIndicator QLabel:disabled {
+#KbIndicator > QLabel:disabled {
     color: #b4b4b4;
 }
 
-#KbIndicator QLabel:enabled {
+#KbIndicator > QLabel:enabled {
     color: white;
     background: #780d0f;
 }

--- a/themes/frost/lxqt-panel.qss
+++ b/themes/frost/lxqt-panel.qss
@@ -479,16 +479,16 @@ border-radius: 3px;
 /*
  * KbIndicator
  */
-#KbIndicator QLabel {
+#KbIndicator > QLabel {
     padding: 3px;
     border: 0px;
 }
 
-#KbIndicator QLabel:disabled {
+#KbIndicator >  QLabel:disabled {
     color: #999999;
 }
 
-#KbIndicator QLabel:enabled {
+#KbIndicator > QLabel:enabled {
     background: palette(highlight);
 }
 

--- a/themes/kde-plasma/lxqt-panel.qss
+++ b/themes/kde-plasma/lxqt-panel.qss
@@ -323,7 +323,7 @@ VolumePopup  > QSlider::sub-page:vertical {
     color: rgba(54, 54, 54, 60%);
 }
 
-#KbIndicator QLabel:enabled {
+#KbIndicator > QLabel:enabled {
     border-top: 3px solid rgba(30, 145, 255, 100%);
     color: rgba(54, 54, 54, 100%);
 }


### PR DESCRIPTION
The QLabel background used in the config dialog was the same as in the
indicator.
Just use more fine-grained controls.

A picture is worth a thousand words:
Before:
![screen-2017-08-03-16-52-21](https://user-images.githubusercontent.com/62877/28931442-f8fe7f28-786d-11e7-88e4-bf238a1fbb25.png)

After:
![screen-2017-08-03-16-51-53](https://user-images.githubusercontent.com/62877/28931452-0649390c-786e-11e7-8500-789c931ab697.png)


